### PR TITLE
fix for mario walking further than the entrance of the castle

### DIFF
--- a/level.py
+++ b/level.py
@@ -48,7 +48,7 @@ class Level:
         for i in COINS:
             i.check()
         self.display()
-        if self.breadth - self.mario.point.y < 10:
+        if self.breadth - self.mario.point.y < 16:
             self.board.status.levelUp()
 
     def display(self):
@@ -85,4 +85,4 @@ class Level:
             else:
                 break
 
-        castle = Castle(self.breadth - 33,self.board)        
+        castle = Castle(self.breadth - 33,self.board)


### PR DESCRIPTION
fix for #1 
the level ended at 9 pixels before the end of the board, but the end of the castle entrance is 15 pixels from the end of the board, so I fixed that.